### PR TITLE
add republish flavor

### DIFF
--- a/src/flavors/republish.js
+++ b/src/flavors/republish.js
@@ -7,6 +7,7 @@ import {
   outSourceIsSelf,
   filterOnEventType,
   filterOnContent,
+  outSkip,
 } from '../filters';
 
 /**
@@ -27,6 +28,7 @@ import {
 
 export const republish = (rule) => (s) => // eslint-disable-line import/prefer-default-export
   s
+    .filter(outSkip)
     .filter(outSourceIsSelf)
 
     .filter(onEventType(rule))

--- a/src/flavors/republish.js
+++ b/src/flavors/republish.js
@@ -1,0 +1,57 @@
+import {
+  printStartPipeline, printEndPipeline,
+  faulty, faultyAsyncStream, faultify,
+} from '../utils';
+
+import {
+  outSourceIsSelf,
+  filterOnEventType,
+  filterOnContent,
+} from '../filters';
+
+/**
+ * used in ESG services
+ * transforms and (re)publishes events
+ * used in listener functions
+ *
+ * interface Rule {
+ *   id: string
+ *   flavor: republish
+ *   eventType: string | string[] | Function
+ *   filters?: Function[]
+ *   toEvent?: string | Function
+ *   source?: string // default 'custom'
+ * }
+ *
+ */
+
+export const republish = (rule) => (s) => // eslint-disable-line import/prefer-default-export
+  s
+    .filter(outSourceIsSelf)
+
+    .filter(onEventType(rule))
+    .tap(printStartPipeline)
+
+    .filter(onContent(rule))
+
+    .flatMap(toEvent(rule))
+    .through(rule.publish({ source: rule.source }))
+
+    .tap(printEndPipeline);
+
+const onEventType = (rule) => faulty((uow) => filterOnEventType(rule, uow));
+const onContent = (rule) => faulty((uow) => filterOnContent(rule, uow));
+
+const toEvent = (rule) =>
+  faultyAsyncStream(async (uow) =>
+    (!rule.toEvent
+      ? uow
+      : {
+        ...uow,
+        event: {
+          ...uow.event,
+          ...(typeof rule.toEvent === 'string'
+            ? { type: rule.toEvent }
+            : await faultify(rule.toEvent)(uow, rule)),
+        },
+      }));

--- a/src/utils/s3.js
+++ b/src/utils/s3.js
@@ -112,7 +112,7 @@ export const pageObjectsFromS3 = ({
   const connector = new Connector({ debug, bucketName });
 
   const listObjects = (uow) => {
-    let ContinuationToken = uow[listRequestField].ContinuationToken;
+    let { ContinuationToken } = uow[listRequestField];
 
     return _((push, next) => {
       const params = {

--- a/test/unit/flavors/republish.test.js
+++ b/test/unit/flavors/republish.test.js
@@ -1,0 +1,142 @@
+import 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  initialize,
+  initializeFrom,
+} from '../../../src';
+
+import { toKinesisRecords, fromKinesis } from '../../../src/from/kinesis';
+
+import { defaultOptions } from '../../../src/utils/opt';
+import { EventBridgeConnector } from '../../../src/connectors';
+
+import { republish } from '../../../src/flavors/republish';
+
+describe('flavors/republish.js', () => {
+  it('should execute', (done) => {
+    const stub = sinon
+      .stub(EventBridgeConnector.prototype, 'putEvents')
+      .resolves({ FailedEntryCount: 0 });
+
+    const rules = [
+      {
+        id: 'internal-external',
+        flavor: republish,
+        eventType: 'thing-updated',
+        filters: [() => true],
+        toEvent: () => ({
+          type: 'thing-updated-external',
+        }),
+        source: 'external',
+      },
+      {
+        id: 'external-internal-simple',
+        flavor: republish,
+        eventType: 'thing-updated-external',
+        toEvent: 'thing-updated',
+      },
+      {
+        id: 'republish-minimal',
+        flavor: republish,
+        eventType: 'thing2-updated',
+      },
+      {
+        id: 'republish-other',
+        flavor: republish,
+        eventType: 'x9',
+      },
+    ];
+
+    const events = toKinesisRecords([
+      {
+        type: 'thing-updated',
+        thing: {
+          id: 'thing0',
+          name: 'Thing0',
+        },
+      },
+      {
+        type: 'thing-updated-external',
+        thing: {
+          id: 'thing0',
+          name: 'Thing0',
+        },
+      },
+      {
+        type: 'thing2-updated',
+        thing: {
+          id: 'thing2',
+          name: 'Thing2',
+        },
+      },
+    ]);
+
+    initialize({ ...initializeFrom(rules) }, defaultOptions)
+      .assemble(fromKinesis(events), false)
+      .collect()
+      .tap((collected) => {
+        // console.log(JSON.stringify(collected, null, 2));
+        expect(collected.length).to.equal(3);
+
+        expect(collected[2].event).to.deep.equal({
+          id: 'shardId-000000000000:0',
+          type: 'thing-updated-external',
+          thing: {
+            id: 'thing0',
+            name: 'Thing0',
+          },
+          tags: {
+            account: 'undefined',
+            region: 'us-west-2',
+            stage: 'undefined',
+            source: 'undefined',
+            functionname: 'undefined',
+            pipeline: 'internal-external',
+            skip: true,
+          },
+        });
+        expect(stub.getCall(2).args[0].Entries[0].Source).to.equal('external');
+
+        expect(collected[0].event).to.deep.equal({
+          id: 'shardId-000000000000:1',
+          type: 'thing-updated',
+          thing: {
+            id: 'thing0',
+            name: 'Thing0',
+          },
+          tags: {
+            account: 'undefined',
+            region: 'us-west-2',
+            stage: 'undefined',
+            source: 'undefined',
+            functionname: 'undefined',
+            pipeline: 'external-internal-simple',
+            skip: true,
+          },
+        });
+        expect(stub.getCall(0).args[0].Entries[0].Source).to.equal('custom');
+
+        expect(collected[1].event).to.deep.equal({
+          id: 'shardId-000000000000:2',
+          type: 'thing2-updated',
+          thing: {
+            id: 'thing2',
+            name: 'Thing2',
+          },
+          tags: {
+            account: 'undefined',
+            region: 'us-west-2',
+            stage: 'undefined',
+            source: 'undefined',
+            functionname: 'undefined',
+            pipeline: 'republish-minimal',
+            skip: true,
+          },
+        });
+        expect(stub.getCall(1).args[0].Entries[0].Source).to.equal('custom');
+      })
+      .done(done);
+  });
+});


### PR DESCRIPTION
Intended to be used in ESGs to transform and (re)publish events. Works any direction (external->internal, internal->external) by using `source` param. I'm using it myself and decided to share.
```typescript
interface Rule {
  id: string
  flavor: republish
  eventType: string | string[] | Function
  filters?: Function[]
  toEvent?: string | Function
  source?: string // default 'custom'
}
```
P.S.  An edit to `utils/s3.js` was made by pretest `eslint --fix`, can do nothing about that.