### PR TITLE
Fix response handling when missing Responses attribute.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-stream",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "object-sizeof": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Create stream processors with AWS Lambda functions.",
   "keywords": [
     "aws",


### PR DESCRIPTION
Per the type signature (https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-lib-dynamodb/TypeAlias/BatchGetCommandOutput/) and in my testing, I've found that SOMETIMES there is no `Responses` attribute on the response from ddb in a `BatchGet` call. This caused the downstream `queries/dynamodb.js.batchGetDynamoDB` helper to fail.

The connector was actually already handling the missing `UnprocessedKeys`, this adds handling for missing `Responses`.