### PR TITLE
Allow integration test option overrides to pass through.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-stream",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "MIT",
       "dependencies": {
         "object-sizeof": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Create stream processors with AWS Lambda functions.",
   "keywords": [
     "aws",

--- a/src/metrics/monitor.js
+++ b/src/metrics/monitor.js
@@ -20,6 +20,6 @@ export const monitor = (handle, opt) => { // eslint-disable-line import/prefer-d
   }
 
   // could collect metrics here
-  return (event, context) => Promise.resolve().then(() => handle(event, context));
+  return (event, context, int) => Promise.resolve().then(() => handle(event, context, int));
   // could collect metrics here in .tap() and .tapCatch()
 };


### PR DESCRIPTION
Allows integration test option overrides to pass through to underlying handler when index handle wrapped in monitor.