### PR TITLE
Label handler level s3 clients.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-stream",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
         "object-sizeof": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Create stream processors with AWS Lambda functions.",
   "keywords": [
     "aws",

--- a/src/flavors/collect.js
+++ b/src/flavors/collect.js
@@ -10,7 +10,6 @@ import {
 
 import {
   filterOnEventType, filterOnContent,
-  outSkip,
 } from '../filters';
 
 import { putDynamoDB } from '../sinks/dynamodb';

--- a/src/flavors/materialize.js
+++ b/src/flavors/materialize.js
@@ -8,7 +8,7 @@ import {
 } from '../sinks/dynamodb';
 import {
   filterOnEventType, filterOnContent,
-  outSkip, outSourceIsSelf,
+  outSourceIsSelf,
 } from '../filters';
 
 export const materialize = (rule) => (s) => s // eslint-disable-line import/prefer-default-export

--- a/src/flavors/materializeS3.js
+++ b/src/flavors/materializeS3.js
@@ -11,7 +11,6 @@ import {
 } from '../sinks/s3';
 import {
   filterOnEventType, filterOnContent,
-  outSkip,
 } from '../filters';
 
 export const materializeS3 = (rule) => (s) => s // eslint-disable-line import/prefer-default-export

--- a/src/from/s3.js
+++ b/src/from/s3.js
@@ -57,7 +57,13 @@ export const fromS3Event = (event, options = {}) =>
         Key: uow.record.s3.s3.object.key,
       },
     }))
-    .through(getObjectFromS3(options))
+    .through(getObjectFromS3({
+      id: 'handler:fromS3',
+      additionalClientOpts: {
+        followRegionRedirects: true,
+      },
+      ...options,
+    }))
     .map((uow) => ({
       ...uow,
       event: JSON.parse(Buffer.from(uow.getResponse.Body), decompress),

--- a/src/utils/claimcheck.js
+++ b/src/utils/claimcheck.js
@@ -14,8 +14,12 @@ export const claimcheck = (opt = {}) => (s) => s // eslint-disable-line import/p
     } : undefined,
   })))
   .through(getObjectFromS3({
+    id: 'handler:claimcheck',
     getRequestField: 'getClaimCheckRequest',
     getResponseField: 'getClaimCheckResponse',
+    additionalClientOpts: {
+      followRegionRedirects: true,
+    },
   }))
   .map(faulty((uow) => clear({
     ...uow,

--- a/test/unit/from/s3.test.js
+++ b/test/unit/from/s3.test.js
@@ -192,18 +192,6 @@ describe('from/s3s.js', () => {
 
     await fromS3Event(event)
       .collect()
-      .tap((collected) => {
-        // console.log(JSON.stringify(collected, null, 2));
-        expect(collected.length).to.equal(1);
-        expect(collected[0].event).to.deep.equal({
-          id: '00000000-0000-0000-0000-000000000000',
-          type: 'thing-created',
-          timestamp: '1595616620000',
-          thing: {
-            name: 'thing1',
-          },
-        });
-      })
       .through(toPromise);
 
     const testClient = new Connector({ debug: debug('test'), bucketName: 'test-bucket', pipelineId: 'handler:fromS3' }).client;

--- a/test/unit/from/s3.test.js
+++ b/test/unit/from/s3.test.js
@@ -2,13 +2,19 @@ import 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import debug from 'debug';
 import {
   fromS3, fromSqsSnsS3, fromS3Event, toS3Records, toSqsSnsS3Records,
 } from '../../../src/from/s3';
 
 import Connector from '../../../src/connectors/s3';
+import { toPromise } from '../../../src/utils';
 
 describe('from/s3s.js', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('should parse records', (done) => {
     const event = toS3Records([
       {
@@ -160,5 +166,47 @@ describe('from/s3s.js', () => {
         });
       })
       .done(done);
+  });
+
+  it('should use a pipeline label to cache regional redirects configuration', async () => {
+    sinon.stub(Connector.prototype, 'getObject').resolves({
+      Key: '1/thing',
+      Body: Buffer.from(JSON.stringify({
+        id: '00000000-0000-0000-0000-000000000000',
+        type: 'thing-created',
+        timestamp: '1595616620000',
+        thing: {
+          name: 'thing1',
+        },
+      })),
+    });
+
+    const event = toSqsSnsS3Records([{
+      bucket: {
+        name: 'my-bucket',
+      },
+      object: {
+        key: '1/thing',
+      },
+    }]);
+
+    await fromS3Event(event)
+      .collect()
+      .tap((collected) => {
+        // console.log(JSON.stringify(collected, null, 2));
+        expect(collected.length).to.equal(1);
+        expect(collected[0].event).to.deep.equal({
+          id: '00000000-0000-0000-0000-000000000000',
+          type: 'thing-created',
+          timestamp: '1595616620000',
+          thing: {
+            name: 'thing1',
+          },
+        });
+      })
+      .through(toPromise);
+
+    const testClient = new Connector({ debug: debug('test'), bucketName: 'test-bucket', pipelineId: 'handler:fromS3' }).client;
+    expect(testClient.config.followRegionRedirects).to.eq(true);
   });
 });

--- a/test/unit/utils/claimcheck.test.js
+++ b/test/unit/utils/claimcheck.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import _ from 'highland';
 
+import debug from 'debug';
 import { claimcheck } from '../../../src/utils/claimcheck';
 
 import Connector from '../../../src/connectors/s3';
@@ -65,5 +66,11 @@ describe('utils/claimcheck.js', () => {
         });
       })
       .done(done);
+  });
+
+  it('should use a pipeline label to cache regional redirects configuration', () => {
+    claimcheck();
+    const testClient = new Connector({ debug: debug('test'), bucketName: 'test-bucket', pipelineId: 'handler:claimcheck' }).client;
+    expect(testClient.config.followRegionRedirects).to.eq(true);
   });
 });


### PR DESCRIPTION
Handler level s3 connectors didn't get a pipeline id passed in, using the 'root' client. This could conflict with pipeline level connector configurations where they might not be passing in the same options.

- Add an id to handler level use of s3 connector. This was in `claimcheck` and `fromS3`.
- Pass in `followRegionRedirects` additional client options in from claim check and fromS3 to allow cross region account access if necessary. In same-region access cases, this has zero impact.