### PR TITLE
[DRAFT] Add source side claimcheck support

### DIFF
--- a/src/sinks/claimcheck.js
+++ b/src/sinks/claimcheck.js
@@ -1,0 +1,65 @@
+import { putObjectToS3 } from './s3';
+
+export const submitClaimcheck = ({
+  id: pipelineId,
+  bucketName = process.env.CLAIMCHECK_BUCKET_NAME || /* istanbul ignore next */ process.env.BUCKET_NAME,
+  putRequestField = 'putClaimcheckRequest',
+  putResponseField = 'putClaimcheckResponse',
+  parallel = Number(process.env.S3_PARALLEL) || Number(process.env.PARALLEL) || 8,
+  /* Parent sink owns the some properties, so defaults not provided. */
+  debug,
+  step,
+  eventField,
+  claimcheckEventField,
+  claimcheckRequiredField,
+  ...opt
+}) => {
+  // If we don't have a bucket...we can't claimcheck.
+  if (!bucketName) return (s) => s;
+
+  const toClaimcheckRequest = (uow) => {
+    if (!uow[eventField] || !uow[claimcheckRequiredField]) return uow;
+
+    return {
+      ...uow,
+      [putRequestField]: {
+        Key: `CLAIMCHECK-${uow[eventField].id}`,
+        Body: JSON.stringify(uow[eventField]),
+      },
+    };
+  };
+
+  const recordClaimcheck = (uow) => {
+    if (!uow[putResponseField] || !uow[putRequestField]) return uow;
+
+    return {
+      ...uow,
+      [claimcheckEventField]: {
+        // We still need some of the attributes from the underlying envelope
+        // to allow it to route/partition properly to downstream services.
+        id: uow[eventField].id,
+        type: uow[eventField].type,
+        partitionKey: uow[eventField].partitionKey,
+        timestamp: uow[eventField].timestamp,
+        s3: {
+          bucket: bucketName,
+          key: uow[putRequestField].Key,
+        },
+      },
+    };
+  };
+
+  return (s) => s
+    .map(toClaimcheckRequest)
+    .through(putObjectToS3({
+      debug,
+      id: pipelineId,
+      bucketName,
+      putRequestField,
+      putResponseField,
+      parallel,
+      step,
+      ...opt,
+    }))
+    .map(recordClaimcheck);
+};

--- a/src/sinks/eventbridge.js
+++ b/src/sinks/eventbridge.js
@@ -8,6 +8,7 @@ import { debug as d } from '../utils/print';
 import { adornStandardTags } from '../utils/tags';
 import { compress } from '../utils/compression';
 import { ratelimit } from '../utils/ratelimit';
+import { submitClaimcheck } from './claimcheck';
 
 export const publishToEventBridge = ({ // eslint-disable-line import/prefer-default-export
   id: pipelineId,
@@ -15,6 +16,8 @@ export const publishToEventBridge = ({ // eslint-disable-line import/prefer-defa
   busName = process.env.BUS_NAME || 'undefined',
   source = process.env.BUS_SRC || 'custom', // could change this to internal vs external/ingress/egress
   eventField = 'event', // is often named emit
+  claimcheckEventField = 'claimcheckEvent',
+  claimcheckRequiredField = 'claimcheckRequired',
   publishRequestEntryField = 'publishRequestEntry',
   publishRequestField = 'publishRequest', // was inputParams
   maxPublishRequestSize = Number(process.env.PUBLISH_MAX_REQ_SIZE) || Number(process.env.MAX_REQ_SIZE) || 256 * 1024,
@@ -29,16 +32,26 @@ export const publishToEventBridge = ({ // eslint-disable-line import/prefer-defa
     pipelineId, debug, retryConfig, ...opt,
   });
 
-  const toPublishRequestEntry = (uow) => ({
-    ...uow,
-    [publishRequestEntryField]: uow[eventField] ? {
-      EventBusName: busName,
-      Source: source,
-      DetailType: uow[eventField].type,
-      Detail: JSON.stringify(uow[eventField],
-        compress(uow[eventField].type !== 'fault' ? opt : { ...opt, compressionIgnore: FAULT_COMPRESSION_IGNORE })),
-    } : undefined,
-  });
+  const compressionCandidate = (uow) => !uow[claimcheckEventField] && uow[eventField] !== 'fault';
+  const compressionOpts = (uow) => (uow[eventField].type !== 'fault' ? opt : { ...opt, compressionIgnore: FAULT_COMPRESSION_IGNORE });
+
+  const toPublishDetail = (uow) => JSON.stringify(
+    uow[claimcheckEventField] ?? uow[eventField],
+    compressionCandidate(uow) ? compress(compressionOpts(uow)) : null,
+  );
+
+  // If we didn't just claimcheck, and we already have a publish request enty, this is a noop.
+  const toPublishRequestEntry = (uow) => ((!uow[claimcheckRequiredField] && uow[publishRequestEntryField])
+    ? uow
+    : ({
+      ...uow,
+      [publishRequestEntryField]: uow[eventField] ? {
+        EventBusName: busName,
+        Source: source,
+        DetailType: uow[eventField].type,
+        Detail: toPublishDetail(uow),
+      } : undefined,
+    }));
 
   const toPublishRequest = (batchUow) => ({
     ...batchUow,
@@ -60,12 +73,34 @@ export const publishToEventBridge = ({ // eslint-disable-line import/prefer-defa
     return _(batchUow.batch[0].metrics?.w(p, step) || p()); // wrap promise in a stream
   };
 
+  const adornClaimcheckRequiredFlag = (uow) => ({
+    ...uow,
+    [claimcheckRequiredField]: uow[publishRequestEntryField]
+      ? Buffer.byteLength(JSON.stringify(uow[publishRequestEntryField])) > maxPublishRequestSize : false,
+  });
+
   return (s) => s
     .map(adornStandardTags(eventField))
 
     .through(ratelimit(opt))
 
+    // Figure out if the publish request entry is greater than the max publish request size
+    // If so, perform a claimcheck on the original event, compute a new publish request entry.
+    // Can't just run through claimcheck first pass, because we're not sure what the size of the
+    // rest of the publish request entry is.
     .map(toPublishRequestEntry)
+    .map(adornClaimcheckRequiredFlag)
+    .through(submitClaimcheck({
+      id: pipelineId,
+      debug,
+      eventField,
+      claimcheckEventField,
+      claimcheckRequiredField,
+      step,
+      ...opt,
+    }))
+    .map(toPublishRequestEntry)
+
     .consume(batchWithSize({
       ...opt,
       batchSize,

--- a/src/utils/claimcheck.js
+++ b/src/utils/claimcheck.js
@@ -2,10 +2,12 @@ import { decompress } from './compression';
 import { faulty } from './faults';
 import { getObjectFromS3 } from '../queries/s3';
 
-// claim-check pattern support
-// https://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html
+/*
+* Claim-check pattern support
+* https://www.enterpriseintegrationpatterns.com/patterns/messaging/StoreInLibrary.html
+*/
 
-export const claimcheck = (opt = {}) => (s) => s // eslint-disable-line import/prefer-default-export
+export const consumeClaimcheck = (opt = {}) => (s) => s
   .map(faulty((uow) => ({
     ...uow,
     getClaimCheckRequest: uow.event.s3 ? {
@@ -36,3 +38,6 @@ const clear = (uow) => {
   }
   return uow;
 };
+
+// Deprecrated - use consumeClaimcheck
+export const claimcheck = consumeClaimcheck;

--- a/test/unit/faults/index.test.js
+++ b/test/unit/faults/index.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import Connector from '../../../src/connectors/eventbridge';
+import S3Connector from '../../../src/connectors/s3';
 
 import { fromKinesis, toKinesisRecords } from '../../../src/from/kinesis';
 import {
@@ -14,10 +15,14 @@ import { defaultOptions } from '../../../src/utils/opt';
 import { compress } from '../../../src/utils/compression';
 
 let publishStub;
+let claimcheckStub;
 
 describe('faults/index.js', () => {
   beforeEach(() => {
+    process.env.CLAIMCHECK_BUCKET_NAME = 'test-bucket-name';
+
     publishStub = sinon.stub(Connector.prototype, 'putEvents').resolves({ FailedEntryCount: 0 });
+    claimcheckStub = sinon.stub(S3Connector.prototype, 'putObject').resolves({});
   });
 
   afterEach(sinon.restore);
@@ -222,5 +227,133 @@ describe('faults/index.js', () => {
         ],
       },
     });
+  });
+
+  it('should claimcheck large faults', (done) => {
+    let e;
+    const simulateHandledError = (uow) => {
+      if (uow.record.kinesis.sequenceNumber === '1') {
+        e = new Error('handled error, has uow attached');
+        e.uow = uow;
+        throw e;
+      } else {
+        return uow;
+      }
+    };
+
+    const events = toKinesisRecords([
+      {
+        type: 'f1',
+      },
+      {
+        type: 'f2',
+        entity: {
+          f1: 'v1',
+          f2: 'v2',
+          longValue: Array(200).fill('a').join(''),
+        },
+        eem: { fields: ['f2'] },
+      },
+      {
+        type: 'f3',
+      },
+    ]);
+
+    fromKinesis(events)
+      .map((uow) => ({
+        ...uow,
+        someResponse: {
+          f3: Buffer.from('v1'),
+          f4: uow.event.eem,
+        },
+      }))
+      .map(simulateHandledError)
+      .errors(faults)
+      // 400 used here to be small enough to require a claimcheck but not so small
+      // that the claimcheck itself exceeds the maximum publish size.
+      .through(flushFaults({ ...defaultOptions, maxPublishRequestSize: 400 }))
+
+      .collect()
+      .tap((collected) => {
+        // console.log(JSON.stringify(collected, null, 2));
+
+        expect(publishStub.calledOnce);
+
+        expect(collected.length).to.equal(3);
+
+        expect(collected[2].event.type).to.equal(FAULT_EVENT_TYPE);
+        expect(collected[2].event.err.name).to.equal('Error');
+        expect(collected[2].event.err.message).to.equal('handled error, has uow attached');
+
+        expect(collected[2].event.tags.functionname).to.equal('undefined');
+        expect(collected[2].event.tags.pipeline).to.equal('undefined');
+
+        expect(collected[2].event.uow).to.deep.equal({
+          pipeline: undefined,
+          record: {
+            eventSource: 'aws:kinesis',
+            eventID: 'shardId-000000000000:1',
+            awsRegion: 'us-west-2',
+            kinesis: {
+              approximateArrivalTimestamp: undefined,
+              sequenceNumber: '1',
+              data: 'eyJ0eXBlIjoiZjIiLCJlbnRpdHkiOnsiZjEiOiJ2MSIsImYyIjoidjIiLCJsb25nVmFsdWUiOiJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYSJ9LCJlZW0iOnsiZmllbGRzIjpbImYyIl19fQ==',
+            },
+          },
+          event: {
+            id: 'shardId-000000000000:1',
+            type: 'f2',
+            entity: {
+              f1: 'v1',
+              f2: '[REDACTED]',
+              longValue: Array(200).fill('a').join(''),
+            },
+            eem: { fields: ['f2'] },
+          },
+          someResponse: {
+            f3: '[BUFFER: 2]',
+            f4: '[CIRCULAR]',
+          },
+        });
+
+        // Claimcheck related
+        expect(claimcheckStub.calledOnce);
+        expect(collected[2].publishRequestEntry).to.deep.equal({
+          EventBusName: 'undefined',
+          Source: 'custom',
+          DetailType: 'fault',
+          Detail: `{\"id\":\"${collected[2].event.id}\",\"type\":\"fault\",\"partitionKey\":\"${collected[2].event.partitionKey}\",\"timestamp\":${collected[2].event.timestamp},\"s3\":{\"bucket\":\"test-bucket-name\",\"key\":\"CLAIMCHECK-${collected[2].event.id}\"}}`,
+        });
+        expect(collected[2].claimcheckRequred);
+        expect(collected[2].putClaimcheckRequest).to.deep.equal({
+          Key: `CLAIMCHECK-${collected[2].event.id}`,
+          Body: JSON.stringify(collected[2].event),
+        });
+        expect(collected[2].putClaimcheckResponse).to.deep.equal({});
+        expect(collected[2].claimcheckEvent).to.deep.equal({
+          id: collected[2].event.id,
+          partitionKey: collected[2].event.partitionKey,
+          timestamp: collected[2].event.timestamp,
+          type: collected[2].event.type,
+          s3: {
+            bucket: 'test-bucket-name',
+            key: `CLAIMCHECK-${collected[2].event.id}`,
+          },
+        });
+        expect(collected[2].publishRequest).to.deep.equal({
+          Entries: [
+            {
+              EventBusName: 'undefined',
+              Source: 'custom',
+              DetailType: 'fault',
+              Detail: `{\"id\":\"${collected[2].event.id}\",\"type\":\"fault\",\"partitionKey\":\"${collected[2].event.partitionKey}\",\"timestamp\":${collected[2].event.timestamp},\"s3\":{\"bucket\":\"test-bucket-name\",\"key\":\"CLAIMCHECK-${collected[2].event.id}\"}}`,
+            },
+          ],
+        });
+        expect(collected[2].publishResponse).to.deep.equal({
+          FailedEntryCount: 0,
+        });
+      })
+      .done(done);
   });
 });

--- a/test/unit/sinks/claimcheck.test.js
+++ b/test/unit/sinks/claimcheck.test.js
@@ -1,0 +1,110 @@
+import 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import debug from 'debug';
+import _ from 'highland';
+
+import S3Connector from '../../../src/connectors/s3';
+import { submitClaimcheck } from '../../../src/sinks/claimcheck';
+
+describe('sinks/claimcheck.js', () => {
+  let claimcheckStub;
+
+  beforeEach(() => {
+    claimcheckStub = sinon.stub(S3Connector.prototype, 'putObject').resolves({});
+  });
+
+  afterEach(sinon.restore);
+
+  it('should bypass claimcheck if no bucket set', (done) => {
+    delete process.env.CLAIMCHECK_BUCKET_NAME;
+
+    const uow = {
+      claimcheckRequired: true,
+      event: {
+        id: 'i1',
+        type: 'e1',
+        timestamp: 12345,
+        partitionKey: 'p1',
+        attr: 'a',
+      },
+    };
+
+    _([uow])
+      .through(submitClaimcheck({
+        id: 'test',
+        debug: debug('test'),
+        step: 'test',
+        eventField: 'event',
+        claimcheckEventField: 'claimcheckEvent',
+        claimcheckRequiredField: 'claimcheckRequired',
+      }))
+      .collect()
+      .tap((collected) => {
+        expect(collected.length).to.equal(1);
+
+        // If nowhere to claimcheck to, should just be a passthrough.
+        expect(collected[0]).to.deep.equal(uow);
+        expect(claimcheckStub.notCalled);
+      })
+      .done(done);
+  });
+
+  it('should claimcheck if uow indicates', (done) => {
+    process.env.CLAIMCHECK_BUCKET_NAME = 'test-bucket';
+
+    const uow = {
+      claimcheckRequired: true,
+      event: {
+        id: 'i1',
+        type: 'e1',
+        timestamp: 12345,
+        partitionKey: 'p1',
+        attr: 'a',
+      },
+    };
+
+    _([uow])
+      .through(submitClaimcheck({
+        id: 'test',
+        debug: debug('test'),
+        step: 'test',
+        eventField: 'event',
+        claimcheckEventField: 'claimcheckEvent',
+        claimcheckRequiredField: 'claimcheckRequired',
+      }))
+      .collect()
+      .tap((collected) => {
+        expect(collected.length).to.equal(1);
+
+        expect(collected[0]).to.deep.equal({
+          claimcheckEvent: {
+            id: 'i1',
+            partitionKey: 'p1',
+            s3: {
+              bucket: 'test-bucket',
+              key: 'CLAIMCHECK-i1',
+            },
+            timestamp: 12345,
+            type: 'e1',
+          },
+          claimcheckRequired: true,
+          event: {
+            attr: 'a',
+            id: 'i1',
+            partitionKey: 'p1',
+            timestamp: 12345,
+            type: 'e1',
+          },
+          putClaimcheckRequest: {
+            Body: '{"id":"i1","type":"e1","timestamp":12345,"partitionKey":"p1","attr":"a"}',
+            Key: 'CLAIMCHECK-i1',
+          },
+          putClaimcheckResponse: {},
+        });
+        expect(claimcheckStub.calledOnce);
+      })
+      .done(done);
+  });
+});


### PR DESCRIPTION
- Adds source side claimcheck support when publishing to EB
- By extension, adds fault claimchecking

TODO:
- [ ] Determine ideal claimcheck key structure. Based on service name? Partition key?
- [ ] Add an option to enable this so it's not on by default
- [ ] Submit PR for es/s3 lake templates to consume claimcheck
- [ ] Submit PR for event hub template to include a claimcheck bucket with lifecycle rule for cleaning up old events