### PR TITLE
Fix memory leak in middleware layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-stream",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "license": "MIT",
       "dependencies": {
         "object-sizeof": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Create stream processors with AWS Lambda functions.",
   "keywords": [
     "aws",

--- a/src/utils/handler.js
+++ b/src/utils/handler.js
@@ -7,8 +7,8 @@ export const mw = (handle, opt) => {
   const stack = [];
 
   const run = (event, context) => {
-    stack.push((n, o, e, c) => handle(e, c, o)); // do the real work last
-    const runner = (index) => Promise.resolve(stack[index](() => runner(index + 1), opt, event, context));
+    const mwStack = [...stack, (n, o, e, c) => handle(e, c, o)]; // Do the real work last
+    const runner = (index) => Promise.resolve(mwStack[index](() => runner(index + 1), opt, event, context));
     return Promise.resolve(runner(0));
   };
 


### PR DESCRIPTION
The mw stack array grows unbounded. On each invocation, a new handler function is pushed onto the existing array.