### PR TITLE
add support for array of disabled pipelines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-stream",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "MIT",
       "dependencies": {
         "object-sizeof": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Create stream processors with AWS Lambda functions.",
   "keywords": [
     "aws",

--- a/src/pipelines/index.js
+++ b/src/pipelines/index.js
@@ -49,8 +49,9 @@ export const initializeFrom = (rules) => rules.reduce(
 );
 
 const assemble = (opt) => (head, includeFaultHandler = true) => {
+  const disabledPipelines = process.env.DISABLED_PIPELINES?.split(',');
   const keys = Object.keys(thePipelines)
-    .filter((k) => !process.env.DISABLED_PIPELINES?.includes(k));
+    .filter((k) => !disabledPipelines?.includes(k));
 
   debug('assemble: %j', keys);
 

--- a/test/unit/pipelines/pipelines.test.js
+++ b/test/unit/pipelines/pipelines.test.js
@@ -12,6 +12,7 @@ import Connector from '../../../src/connectors/eventbridge';
 describe('pipelines/index.js', () => {
   beforeEach(() => {
     sinon.stub(Connector.prototype, 'putEvents').resolves({ FailedEntryCount: 0 });
+    delete process.env.DISABLED_PIPELINES;
   });
   afterEach(sinon.restore);
 
@@ -41,6 +42,65 @@ describe('pipelines/index.js', () => {
         // console.log(JSON.stringify(collected, null, 2));
         expect(collected.length).to.equal(3);
         expect(counter).to.equal(3);
+      })
+      .done(done);
+  });
+
+  it('should ignore disabled pipelines - string', (done) => {
+    process.env.DISABLED_PIPELINES = 'p1a';
+    let counter = 0;
+
+    const count = (uow) => {
+      uow.counter = counter++; // eslint-disable-line no-plusplus
+      return uow;
+    };
+
+    const events = toKinesisRecords([{
+      type: 't1',
+    }]);
+
+    initialize({
+      p1: (opt) => (s) => s.map(count),
+      p1a: (opt) => (s) => s.map(count),
+      p1b: (opt) => (s) => s.map(count),
+    })
+      .assemble(fromKinesis(events), false)
+      .collect()
+      .tap((collected) => {
+        // console.log(JSON.stringify(collected, null, 2));
+        expect(collected.length).to.equal(2);
+        expect(counter).to.equal(2);
+        expect(collected[0].pipeline).to.equal('p1b');
+        expect(collected[1].pipeline).to.equal('p1');
+      })
+      .done(done);
+  });
+
+  it('should ignore disabled pipelines - array', (done) => {
+    process.env.DISABLED_PIPELINES = ['p1', 'p2'];
+    let counter = 0;
+
+    const count = (uow) => {
+      uow.counter = counter++; // eslint-disable-line no-plusplus
+      return uow;
+    };
+
+    const events = toKinesisRecords([{
+      type: 't1',
+    }]);
+
+    initialize({
+      p1: (opt) => (s) => s.map(count),
+      p2: (opt) => (s) => s.map(count),
+      p3: (opt) => (s) => s.map(count),
+    })
+      .assemble(fromKinesis(events), false)
+      .collect()
+      .tap((collected) => {
+        // console.log(JSON.stringify(collected, null, 2));
+        expect(collected.length).to.equal(1);
+        expect(counter).to.equal(1);
+        expect(collected[0].pipeline).to.equal('p3');
       })
       .done(done);
   });


### PR DESCRIPTION
This makes the DISABLED_PIPELINES environment variable allows for an array of pipelines to disable, and also requires the pipeline name to match exactly. It also supports setting DISABLED_PIPELINES to a string, but does require an exact match on pipeline name.

There is a side effect to this MR. If you look in the test `'should ignore disabled pipelines - string'`, (without these source code changes), setting DISABLED_PIPELINES to "p1a" would disable "p1" and "p1a", not just "p1a".