### PR TITLE
Batch by total request message size.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-stream",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
         "object-sizeof": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Create stream processors with AWS Lambda functions.",
   "keywords": [
     "aws",

--- a/src/sinks/sqs.js
+++ b/src/sinks/sqs.js
@@ -13,7 +13,7 @@ export const sendToSqs = ({ // eslint-disable-line import/prefer-default-export
   queueUrl = process.env.QUEUE_URL,
   messageField = 'message',
   batchSize = Number(process.env.SQS_BATCH_SIZE) || Number(process.env.BATCH_SIZE) || 10,
-  maxPayloadSize = Number(process.env.SQS_MAX_PAYLOAD_SIZE) || Number(process.env.MAX_PAYLOAD_SIZE) || 256 * 1024,
+  maxPayloadSize = Number(process.env.SQS_MAX_PAYLOAD_SIZE) || Number(process.env.MAX_PAYLOAD_SIZE) || 1024 * 1024,
   parallel = Number(process.env.SQS_PARALLEL) || Number(process.env.PARALLEL) || 8,
   step = 'send',
   ...opt

--- a/src/sinks/sqs.js
+++ b/src/sinks/sqs.js
@@ -2,7 +2,7 @@ import _ from 'highland';
 
 import Connector from '../connectors/sqs';
 
-import { toBatchUow, unBatchUow } from '../utils/batch';
+import { batchWithPayloadSizeOrCount, toBatchUow, unBatchUow } from '../utils/batch';
 import { ratelimit } from '../utils/ratelimit';
 import { rejectWithFault } from '../utils/faults';
 import { debug as d } from '../utils/print';
@@ -13,6 +13,7 @@ export const sendToSqs = ({ // eslint-disable-line import/prefer-default-export
   queueUrl = process.env.QUEUE_URL,
   messageField = 'message',
   batchSize = Number(process.env.SQS_BATCH_SIZE) || Number(process.env.BATCH_SIZE) || 10,
+  maxPayloadSize = Number(process.env.SQS_MAX_PAYLOAD_SIZE) || Number(process.env.MAX_PAYLOAD_SIZE) || 256 * 1024,
   parallel = Number(process.env.SQS_PARALLEL) || Number(process.env.PARALLEL) || 8,
   step = 'send',
   ...opt
@@ -46,7 +47,12 @@ export const sendToSqs = ({ // eslint-disable-line import/prefer-default-export
   return (s) => s
     .through(ratelimit(opt))
 
-    .batch(batchSize)
+    .consume(batchWithPayloadSizeOrCount({
+      batchSize,
+      maxPayloadSize,
+      payloadField: messageField,
+      ...opt,
+    }))
     .map(toBatchUow)
 
     .map(toInputParams)

--- a/src/utils/batch.js
+++ b/src/utils/batch.js
@@ -50,8 +50,7 @@ export const compact = (rule) => {
 };
 
 /**
- * Batch EB request entries by size to avoid writing a batch that's too large to
- * EB.
+ * Batch EB request entries by size to avoid writing a batch that's too large to EB.
  */
 export const batchWithSize = ({
   claimCheckBucketName = process.env.CLAIMCHECK_BUCKET_NAME,


### PR DESCRIPTION
Per the aws docs for [SendMessageBatch](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-client-sqs/Class/SendMessageBatchCommand/):
`The maximum allowed individual message size and the maximum total payload size (the sum of the individual lengths of all of the batched messages) are both 256 KiB (262,144 bytes).`

- Adds a batchWithPayloadSizeOrCount that is JUST batching and doesn't deal with any of the claimcheck logic.
- Adds batching per request size in addition to the message count to the SQS sink.