### PR TITLE
Fix DDB stream TTL REMOVE event filtering.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-stream",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "license": "MIT",
       "dependencies": {
         "object-sizeof": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Create stream processors with AWS Lambda functions.",
   "keywords": [
     "aws",

--- a/src/from/dynamodb.js
+++ b/src/from/dynamodb.js
@@ -194,9 +194,6 @@ export const toDynamodbRecords = (events, { removeUndefinedValues = true } = {})
       eventSource: 'aws:dynamodb',
       awsRegion: e.newImage?.awsregion || process.env.AWS_REGION || /* istanbul ignore next */ 'us-west-2',
       dynamodb: {
-        // TODO - Fix this in next major version bump. ApproximateCreationDateTime is meant to be in seconds, not millis.
-        // Didn't want to fix until a major version bump to avoid compatibility issues for consumers
-        // upgrading the lib. This should be e.timestamp / 1000
         ApproximateCreationDateTime: e.timestamp,
         Keys: e.keys ? marshall(e.keys, { removeUndefinedValues }) : /* istanbul ignore next */ undefined,
         NewImage: e.newImage ? marshall(e.newImage, { removeUndefinedValues }) : undefined,

--- a/test/unit/from/dynamodb.test.js
+++ b/test/unit/from/dynamodb.test.js
@@ -919,9 +919,10 @@ describe('from/dynamodb.js', () => {
           ttl: 1573005490,
           timestamp: 1573005490000,
         },
+        ttlDelete: true,
       },
       {
-        timestamp: 1573005490,
+        timestamp: 1573005490000,
         keys: {
           pk: '1',
           sk: 'thing',
@@ -930,7 +931,7 @@ describe('from/dynamodb.js', () => {
           pk: '1',
           sk: 'thing',
           name: 'N1',
-          ttl: 1573015490, // hasn't expired yet
+          ttl: 1573015490, // has expired, but event is not a ddb ttl remove
           timestamp: 1573005490000,
         },
       },

--- a/test/unit/from/dynamodb.test.js
+++ b/test/unit/from/dynamodb.test.js
@@ -907,7 +907,7 @@ describe('from/dynamodb.js', () => {
   it('should ignore expired ttl', (done) => {
     const events = toDynamodbRecords([
       {
-        timestamp: 1573005490000,
+        timestamp: 1573005490,
         keys: {
           pk: '1',
           sk: 'thing',
@@ -922,7 +922,7 @@ describe('from/dynamodb.js', () => {
         ttlDelete: true,
       },
       {
-        timestamp: 1573005490000,
+        timestamp: 1573005490,
         keys: {
           pk: '1',
           sk: 'thing',
@@ -931,7 +931,7 @@ describe('from/dynamodb.js', () => {
           pk: '1',
           sk: 'thing',
           name: 'N1',
-          ttl: 1573015490, // has expired, but event is not a ddb ttl remove
+          ttl: 1573015491,
           timestamp: 1573005490000,
         },
       },
@@ -983,6 +983,45 @@ describe('from/dynamodb.js', () => {
       .tap((collected) => {
         // console.log(JSON.stringify(collected, null, 2));
         expect(collected.length).to.equal(1);
+      })
+      .done(done);
+  });
+
+  it('should passes through record with no ttl if ignore ttl events is true', (done) => {
+    const events = toDynamodbRecords([
+      {
+        timestamp: 1573005491,
+        keys: {
+          pk: '1',
+          sk: 'thing',
+        },
+        oldImage: {
+          pk: '1',
+          sk: 'thing',
+          name: 'N1',
+          timestamp: 1573005490000,
+        },
+      },
+      {
+        timestamp: 1573005490,
+        keys: {
+          pk: '1',
+          sk: 'thing',
+        },
+        oldImage: {
+          pk: '1',
+          sk: 'thing',
+          name: 'N1',
+          timestamp: 1573005490000,
+        },
+      },
+    ]);
+
+    fromDynamodb(events, { ignoreTtlExpiredEvents: true })
+      .collect()
+      .tap((collected) => {
+        // console.log(JSON.stringify(collected, null, 2));
+        expect(collected.length).to.equal(2);
       })
       .done(done);
   });


### PR DESCRIPTION
- Updates the TTL filtering based on AWS docs for identifying TTL REMOVEs on the CDC stream.
- Falls back to ttl check against approx create time when identity attributes not present indicating potential replicated ttl remove.
- Adds a `ttlDelete` option to the `toDynamodbRecords` test helper.