### PR TITLE
Task/key name safe replacement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-stream",
-      "version": "1.1.17",
+      "version": "1.1.18",
       "license": "MIT",
       "dependencies": {
         "object-sizeof": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-stream",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "Create stream processors with AWS Lambda functions.",
   "keywords": [
     "aws",

--- a/src/sinks/dynamodb.js
+++ b/src/sinks/dynamodb.js
@@ -13,10 +13,12 @@ export const updateExpression = (Item) => {
       // If this attribute ends with '_delete'...assume we're deleting values from a set.
       const isDeleteSet = key.endsWith('_delete');
       const baseKey = isDeleteSet ? key.replace(/_delete$/, '') : key;
-      acc.ExpressionAttributeNames[`#${baseKey}`] = baseKey;
+      const keyNameSafe = baseKey.replace(/[^a-zA-Z0-9_\-.]/g, '_');
+
+      acc.ExpressionAttributeNames[`#${keyNameSafe}`] = baseKey;
 
       if (value === null) {
-        acc.removeClauses.push(`#${baseKey}`);
+        acc.removeClauses.push(`#${keyNameSafe}`);
         return acc;
       }
 
@@ -25,19 +27,19 @@ export const updateExpression = (Item) => {
         if (!(setValue instanceof Set)) {
           setValue = new Set([setValue]);
         }
-        acc.ExpressionAttributeValues[`:${key}`] = setValue;
-        acc.deleteClauses.push(`#${baseKey} :${key}`);
+        acc.ExpressionAttributeValues[`:${keyNameSafe}_delete`] = setValue;
+        acc.deleteClauses.push(`#${keyNameSafe} :${keyNameSafe}_delete`);
         return acc;
       }
 
       if (value instanceof Set) {
-        acc.ExpressionAttributeValues[`:${key}`] = value;
-        acc.addClauses.push(`#${key} :${key}`);
+        acc.ExpressionAttributeValues[`:${keyNameSafe}`] = value;
+        acc.addClauses.push(`#${keyNameSafe} :${keyNameSafe}`);
         return acc;
       }
 
-      acc.ExpressionAttributeValues[`:${key}`] = value;
-      acc.setClauses.push(`#${key} = :${key}`);
+      acc.ExpressionAttributeValues[`:${keyNameSafe}`] = value;
+      acc.setClauses.push(`#${keyNameSafe} = :${keyNameSafe}`);
       return acc;
     }, {
       ExpressionAttributeNames: {},

--- a/src/sinks/dynamodb.js
+++ b/src/sinks/dynamodb.js
@@ -13,12 +13,12 @@ export const updateExpression = (Item) => {
       // If this attribute ends with '_delete'...assume we're deleting values from a set.
       const isDeleteSet = key.endsWith('_delete');
       const baseKey = isDeleteSet ? key.replace(/_delete$/, '') : key;
-      const keyNameSafe = baseKey.replace(/[^a-zA-Z0-9_\-.]/g, '_');
+      const alias = baseKey.replace(/([^a-z0-9_]+)/gi, '_');
 
-      acc.ExpressionAttributeNames[`#${keyNameSafe}`] = baseKey;
+      acc.ExpressionAttributeNames[`#${alias}`] = baseKey;
 
       if (value === null) {
-        acc.removeClauses.push(`#${keyNameSafe}`);
+        acc.removeClauses.push(`#${alias}`);
         return acc;
       }
 
@@ -27,19 +27,19 @@ export const updateExpression = (Item) => {
         if (!(setValue instanceof Set)) {
           setValue = new Set([setValue]);
         }
-        acc.ExpressionAttributeValues[`:${keyNameSafe}_delete`] = setValue;
-        acc.deleteClauses.push(`#${keyNameSafe} :${keyNameSafe}_delete`);
+        acc.ExpressionAttributeValues[`:${alias}_delete`] = setValue;
+        acc.deleteClauses.push(`#${alias} :${alias}_delete`);
         return acc;
       }
 
       if (value instanceof Set) {
-        acc.ExpressionAttributeValues[`:${keyNameSafe}`] = value;
-        acc.addClauses.push(`#${keyNameSafe} :${keyNameSafe}`);
+        acc.ExpressionAttributeValues[`:${alias}`] = value;
+        acc.addClauses.push(`#${alias} :${alias}`);
         return acc;
       }
 
-      acc.ExpressionAttributeValues[`:${keyNameSafe}`] = value;
-      acc.setClauses.push(`#${keyNameSafe} = :${keyNameSafe}`);
+      acc.ExpressionAttributeValues[`:${alias}`] = value;
+      acc.setClauses.push(`#${alias} = :${alias}`);
       return acc;
     }, {
       ExpressionAttributeNames: {},

--- a/src/sinks/dynamodb.js
+++ b/src/sinks/dynamodb.js
@@ -13,7 +13,8 @@ export const updateExpression = (Item) => {
       // If this attribute ends with '_delete'...assume we're deleting values from a set.
       const isDeleteSet = key.endsWith('_delete');
       const baseKey = isDeleteSet ? key.replace(/_delete$/, '') : key;
-      const alias = baseKey.replace(/([^a-z0-9_]+)/gi, '_');
+      const alias = baseKey.replace(/([^a-z0-9_])/gi, (char) =>
+        `_x${char.charCodeAt(0).toString(16)}_`);
 
       acc.ExpressionAttributeNames[`#${alias}`] = baseKey;
 

--- a/test/unit/sinks/dynamodb.test.js
+++ b/test/unit/sinks/dynamodb.test.js
@@ -21,15 +21,17 @@ describe('sinks/dynamodb.js', () => {
 
   it('should calculate updateExpression', () => {
     expect(updateExpression({
-      id: '2f8ac025-d9e3-48f9-ba80-56487ddf0b89',
-      name: 'Thing One',
-      description: 'This is thing one.',
-      status: undefined,
-      status2: null,
-      discriminator: 'thing',
-      latched: true,
-      ttl: ttl(1540454400000, 30),
-      timestamp: 1540454400000,
+      'id': '2f8ac025-d9e3-48f9-ba80-56487ddf0b89',
+      'name': 'Thing One',
+      'description': 'This is thing one.',
+      'status': undefined,
+      'status2': null,
+      'discriminator': 'thing',
+      'latched': true,
+      'ttl': ttl(1540454400000, 30),
+      'timestamp': 1540454400000,
+      'some unsafe att name': true,
+      'some unsafe att name to delete': null,
     })).to.deep.equal({
       ExpressionAttributeNames: {
         '#description': 'description',
@@ -37,6 +39,8 @@ describe('sinks/dynamodb.js', () => {
         '#id': 'id',
         '#latched': 'latched',
         '#name': 'name',
+        '#some_unsafe_att_name': 'some unsafe att name',
+        '#some_unsafe_att_name_to_delete': 'some unsafe att name to delete',
         // '#status': 'status',
         '#status2': 'status2',
         '#timestamp': 'timestamp',
@@ -48,12 +52,13 @@ describe('sinks/dynamodb.js', () => {
         ':id': '2f8ac025-d9e3-48f9-ba80-56487ddf0b89',
         ':latched': true,
         ':name': 'Thing One',
+        ':some_unsafe_att_name': true,
         // ':status': undefined,
         // ':status2': null,
         ':timestamp': 1540454400000,
         ':ttl': 1543046400,
       },
-      UpdateExpression: 'SET #id = :id, #name = :name, #description = :description, #discriminator = :discriminator, #latched = :latched, #ttl = :ttl, #timestamp = :timestamp REMOVE #status2',
+      UpdateExpression: 'SET #id = :id, #name = :name, #description = :description, #discriminator = :discriminator, #latched = :latched, #ttl = :ttl, #timestamp = :timestamp, #some_unsafe_att_name = :some_unsafe_att_name REMOVE #status2, #some_unsafe_att_name_to_delete',
       ReturnValues: 'ALL_NEW',
     });
   });
@@ -88,6 +93,23 @@ describe('sinks/dynamodb.js', () => {
         ':tags_delete': ['x', 'y'],
       },
       UpdateExpression: 'DELETE #tags :tags_delete',
+      ReturnValues: 'ALL_NEW',
+    });
+  });
+
+  it('should calculate updateExpression removing values from a set when attribute names have illegal characters if used as an alias', () => {
+    const result = updateExpression({
+      'some|tags_delete': new Set(['x', 'y']),
+    });
+
+    expect(normalizeObj(result)).to.deep.equal({
+      ExpressionAttributeNames: {
+        '#some_tags': 'some|tags',
+      },
+      ExpressionAttributeValues: {
+        ':some_tags_delete': ['x', 'y'],
+      },
+      UpdateExpression: 'DELETE #some_tags :some_tags_delete',
       ReturnValues: 'ALL_NEW',
     });
   });

--- a/test/unit/sinks/dynamodb.test.js
+++ b/test/unit/sinks/dynamodb.test.js
@@ -39,9 +39,8 @@ describe('sinks/dynamodb.js', () => {
         '#id': 'id',
         '#latched': 'latched',
         '#name': 'name',
-        '#some_unsafe_att_name': 'some unsafe att name',
-        '#some_unsafe_att_name_to_delete': 'some unsafe att name to delete',
-        // '#status': 'status',
+        '#some_x20_unsafe_x20_att_x20_name': 'some unsafe att name',
+        '#some_x20_unsafe_x20_att_x20_name_x20_to_x20_delete': 'some unsafe att name to delete',
         '#status2': 'status2',
         '#timestamp': 'timestamp',
         '#ttl': 'ttl',
@@ -52,13 +51,11 @@ describe('sinks/dynamodb.js', () => {
         ':id': '2f8ac025-d9e3-48f9-ba80-56487ddf0b89',
         ':latched': true,
         ':name': 'Thing One',
-        ':some_unsafe_att_name': true,
-        // ':status': undefined,
-        // ':status2': null,
+        ':some_x20_unsafe_x20_att_x20_name': true,
         ':timestamp': 1540454400000,
         ':ttl': 1543046400,
       },
-      UpdateExpression: 'SET #id = :id, #name = :name, #description = :description, #discriminator = :discriminator, #latched = :latched, #ttl = :ttl, #timestamp = :timestamp, #some_unsafe_att_name = :some_unsafe_att_name REMOVE #status2, #some_unsafe_att_name_to_delete',
+      UpdateExpression: 'SET #id = :id, #name = :name, #description = :description, #discriminator = :discriminator, #latched = :latched, #ttl = :ttl, #timestamp = :timestamp, #some_x20_unsafe_x20_att_x20_name = :some_x20_unsafe_x20_att_x20_name REMOVE #status2, #some_x20_unsafe_x20_att_x20_name_x20_to_x20_delete',
       ReturnValues: 'ALL_NEW',
     });
   });
@@ -100,16 +97,28 @@ describe('sinks/dynamodb.js', () => {
   it('should calculate updateExpression removing values from a set when attribute names have illegal characters if used as an alias', () => {
     const result = updateExpression({
       'some|tags_delete': new Set(['x', 'y']),
+      'a-b': true,
+      'a--b': false,
+      'a|b': 1,
     });
 
     expect(normalizeObj(result)).to.deep.equal({
       ExpressionAttributeNames: {
-        '#some_tags': 'some|tags',
+        '#some_x7c_tags': 'some|tags',
+        '#a_x2d_b': 'a-b',
+        '#a_x2d__x2d_b': 'a--b',
+        '#a_x7c_b': 'a|b',
       },
       ExpressionAttributeValues: {
-        ':some_tags_delete': ['x', 'y'],
+        ':some_x7c_tags_delete': [
+          'x',
+          'y',
+        ],
+        ':a_x2d_b': true,
+        ':a_x2d__x2d_b': false,
+        ':a_x7c_b': 1,
       },
-      UpdateExpression: 'DELETE #some_tags :some_tags_delete',
+      UpdateExpression: 'SET #a_x2d_b = :a_x2d_b, #a_x2d__x2d_b = :a_x2d__x2d_b, #a_x7c_b = :a_x7c_b DELETE #some_x7c_tags :some_x7c_tags_delete',
       ReturnValues: 'ALL_NEW',
     });
   });


### PR DESCRIPTION
- change `#some-key` and `:some-key` to take into account a string that is not allowed to be used in ExpresssionAttributeNames
    - before, this would throw an error during the DB update `updateExpression({'some-key': true})`
    - even though 'some-key' is valid as an attribute for a db row in dynamodb, just not as an alias
- updated all of the paths inside of updateExpression() so that consistently makes the key name safe before using it as an alias, not just using it as-is
- actual key is untouched and still used in the write as the attribute

```javascript
//before
updateExpression({'some-var': 'some value'});
/* this would actually cause an error when executing the update because of the hyphens in #some-var and :some-var
{
            
            ExpressionAttributeNames: {
              '#some-var': 'some-var'
            },
            ExpressionAttributeValues: {
              ':some-var': 'some value'
            },
            UpdateExpression:
              'SET #some-var = :some-var',
            ReturnValues: 'ALL_NEW',
          }
*/

//after
updateExpression({'some-var': 'some value'});
/*
{
            
            ExpressionAttributeNames: {
              '#some_x2d_var': 'some-var'
            },
            ExpressionAttributeValues: {
              ':some_x2d_var': 'some value'
            },
            UpdateExpression:
              'SET #some_x2d_var = :some_x2d_var',
            ReturnValues: 'ALL_NEW',
          }
*/

```